### PR TITLE
Add deployment options to hugo.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,13 @@
+steps:
+  - name: $_BUILDER_IMAGE
+    args:
+      - hugo
+  - name: $_BUILDER_IMAGE
+    args:
+      - hugo
+      - deploy
+      - target=gcp
+options:
+  logging: CLOUD_LOGGING_ONLY
+substitutions:
+  _BUILDER_IMAGE: 'hugomods/hugo:exts'

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -56,3 +56,10 @@ outputs:
     - HTML
     - aacfeed
     - mp3feed
+
+deployment:
+  targets:
+    - name: gcp
+      URL: gs://flippin-out-html/
+    - name: r2
+      URL: s3://podcast-html?endpoint=a05b845319257ed29946e5409ba8aafc.r2.cloudflarestorage.com&disableSSL=true&s3ForcePathStyle=true&region=auto

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -51,6 +51,8 @@ outputFormats:
     noUgly: true
     Rel: "alternate"
 
+env: production
+
 outputs:
   home:
     - HTML

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -62,4 +62,4 @@ deployment:
     - name: gcp
       URL: gs://flippin-out-html/
     - name: r2
-      URL: s3://podcast-html?endpoint=a05b845319257ed29946e5409ba8aafc.r2.cloudflarestorage.com&disableSSL=true&s3ForcePathStyle=true&region=auto
+      URL: s3://podcast-html?endpoint=a05b845319257ed29946e5409ba8aafc.r2.cloudflarestorage.com&s3ForcePathStyle=true&region=auto


### PR DESCRIPTION
Both of these work assuming you have appropriate default auth set up locally for gcloud or cloudflare R2.

The GCP option currently works in an automated build, and I'll work on getting auth set up for R2 with automated builds after I think about that a bit.